### PR TITLE
Add a no-op `flush` function for compatibility

### DIFF
--- a/lib/ramdisk.ml
+++ b/lib/ramdisk.ml
@@ -117,3 +117,5 @@ let resize x new_size_sectors =
   x.map <- to_keep;
   x.info <- { x.info with size_sectors = new_size_sectors };
   Lwt.return (`Ok ())
+
+let flush x = Lwt.return (`Ok ())

--- a/lib/ramdisk.mli
+++ b/lib/ramdisk.mli
@@ -51,3 +51,8 @@ val seek_mapped: t -> int64 -> [ `Ok of int64 | `Error of error ] io
 (** [seek_mapped t start] returns the offset of the next regoin of the
     device which may have data in it (typically this is the next mapped
     region) *)
+
+(** {6 Compatibility} *)
+
+val flush : t -> [ `Ok of unit | `Error of error ] io
+(** [flush t] is a no-op on a Ramdisk *)


### PR DESCRIPTION
Signed-off-by: David Scott dave@recoil.org
