### PR TITLE
resize should return a write_error

### DIFF
--- a/src/ramdisk.mli
+++ b/src/ramdisk.mli
@@ -35,7 +35,7 @@ val destroy: name:string -> unit
 
 (** {6 Resizing support} *)
 
-val resize : t -> int64 -> (unit, error) result io
+val resize : t -> int64 -> (unit, write_error) result io
 (** [resize t new_size_sectors] attempts to resize the connected device
     to have the given number of sectors. If successful, subsequent calls
     to [get_info] will reflect the new size. *)


### PR DESCRIPTION
Resize modifies the block device, so should return a write_error.

Signed-off-by: David Scott <dave@recoil.org>