### PR TITLE
Adapt to mirage-block.2.0.{0,1} changes

### DIFF
--- a/mirage-block-ramdisk.opam
+++ b/mirage-block-ramdisk.opam
@@ -7,13 +7,14 @@ homepage: "https://github.com/mirage/mirage-block-ramdisk"
 doc: "https://mirage.github.io/mirage-block-ramdisk/"
 bug-reports: "https://github.com/mirage/mirage-block-ramdisk/issues"
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.1"}
   "dune"
   "alcotest" {with-test}
   "cstruct"
   "io-page"
   "io-page-unix" {with-test}
-  "mirage-block-lwt" {>= "1.0.0"}
+  "mirage-block" {>= "2.0.0"}
+  "mirage-block-combinators" {with-test & >= "2.0.0"}
   "lwt"
 ]
 build: [

--- a/src/dune
+++ b/src/dune
@@ -1,6 +1,6 @@
 (library
  (name mirage_block_ramdisk)
  (public_name mirage-block-ramdisk)
- (libraries cstruct io-page lwt mirage-block-lwt)
+ (libraries cstruct io-page lwt mirage-block)
  (wrapped false)
 )

--- a/src/ramdisk.ml
+++ b/src/ramdisk.ml
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type 'a io = 'a Lwt.t
-
 (* NB not actually page-aligned *)
 type page_aligned_buffer = Cstruct.t
 

--- a/src/ramdisk.mli
+++ b/src/ramdisk.mli
@@ -18,13 +18,13 @@
 
 (** {2 Basic operation} *)
 
-include Mirage_block_lwt.S
+include Mirage_block.S
 
-val connect: name:string -> t io
+val connect: name:string -> t Lwt.t
 (** Connect to the named ramdisk. *)
 
 val create: name:string -> size_sectors:int64 -> sector_size:int
-  -> (t, error) result io
+  -> (t, error) result Lwt.t
 (** Create an in-memory block device (a "ramdisk") with a given name,
     total size in sectors and sector size. Two calls to [connect] with the
     same name will return the same block device *)
@@ -35,23 +35,23 @@ val destroy: name:string -> unit
 
 (** {2 Resizing support} *)
 
-val resize : t -> int64 -> (unit, write_error) result io
+val resize : t -> int64 -> (unit, write_error) result Lwt.t
 (** [resize t new_size_sectors] attempts to resize the connected device
     to have the given number of sectors. If successful, subsequent calls
     to [get_info] will reflect the new size. *)
 
 (** {2 Querying sparseness information} *)
 
-val seek_unmapped: t -> int64 -> (int64, error) result io
+val seek_unmapped: t -> int64 -> (int64, error) result Lwt.t
 (** [seek_unmapped t start] returns the offset of the next guaranteed
     zero-filled region (typically guaranteed because it is unmapped) *)
 
-val seek_mapped: t -> int64 -> (int64, error) result io
+val seek_mapped: t -> int64 -> (int64, error) result Lwt.t
 (** [seek_mapped t start] returns the offset of the next regoin of the
     device which may have data in it (typically this is the next mapped
     region) *)
 
 (** {2 Compatibility} *)
 
-val flush : t -> (unit, write_error) result io
+val flush : t -> (unit, write_error) result Lwt.t
 (** [flush t] is a no-op on a Ramdisk *)

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (test
  (name tests)
- (libraries mirage-block-ramdisk mirage-block-lwt lwt alcotest lwt.unix io-page-unix)
+ (libraries mirage-block-ramdisk mirage-block mirage-block-combinators lwt
+  alcotest lwt.unix io-page-unix)
 )

--- a/test/tests.ml
+++ b/test/tests.ml
@@ -16,11 +16,11 @@
  *)
 open Lwt.Infix
 
-module Compare = Mirage_block_lwt.Compare(Ramdisk)(Ramdisk)
-module Fill = Mirage_block_lwt.Fill(Ramdisk)
-module Safe = Mirage_block_lwt.Make_safe(Ramdisk)
-module Copy = Mirage_block_lwt.Copy(Ramdisk)(Ramdisk)
-module Sparse_copy = Mirage_block_lwt.Sparse_copy(Ramdisk)(Ramdisk)
+module Compare = Mirage_block_combinators.Compare(Ramdisk)(Ramdisk)
+module Fill = Mirage_block_combinators.Fill(Ramdisk)
+module Safe = Mirage_block_combinators.Make_safe(Ramdisk)
+module Copy = Mirage_block_combinators.Copy(Ramdisk)(Ramdisk)
+module Sparse_copy = Mirage_block_combinators.Sparse_copy(Ramdisk)(Ramdisk)
 
 let expect_ok msg = function
   | Error _ -> failwith msg


### PR DESCRIPTION
Hi!
`mirage-block.2.0.{0,1}` have been released with some breaking changes, this PR fixes the incompatibilities to be able to use the latest versions.