### PR TITLE
Restore compatibility with Alcotest.1.4.0

### DIFF
--- a/test/tests.ml
+++ b/test/tests.ml
@@ -27,13 +27,13 @@ let expect_ok msg = function
   | Ok x -> x
 
 let expect_ok_msg pp_error = function
-  | Error e -> Fmt.kstrf Alcotest.fail "%a" pp_error e
+  | Error e -> Fmt.kstrf (fun s -> Alcotest.fail s) "%a" pp_error e
   | Ok x   -> x
 
 let expect_unsafe pp_error = function
   | Error (`Unsafe _) -> ()
   | Ok _              -> Alcotest.fail "unexpected ok"
-  | Error e           -> Fmt.kstrf Alcotest.fail "%a" pp_error e
+  | Error e           -> Fmt.kstrf (fun s -> Alcotest.fail s) "%a" pp_error e
 
 let ramdisk_compare () =
   let t =


### PR DESCRIPTION
The Alcotest 1.4.0 release adds optional arguments to Alcotest.fail.  Eta-expansion is necessary to use this function with the continuation printers.